### PR TITLE
Add Devin trigger and PR polling scripts

### DIFF
--- a/.devin/guidelines.md
+++ b/.devin/guidelines.md
@@ -10,10 +10,14 @@ Boozang TheLab is an interactive educational web application for teaching test a
 
 ### Starting a New Task
 
-1. Review the journal for recent context and learnings
-2. Create a feature branch: `git checkout -b devin/{timestamp}-{description}`
-3. Understand the existing code patterns before making changes
-4. Run `npm run build` to verify the codebase compiles
+1. **Fix branch tracking if needed:** The default branch is `main` (not `master`). If `git pull` fails with "no such ref", run:
+   ```bash
+   git branch -m master main && git fetch origin && git branch -u origin/main main && git remote set-head origin -a
+   ```
+2. Review the journal for recent context and learnings
+3. Create a feature branch from `main`: `git checkout -b devin/{timestamp}-{description}`
+4. Understand the existing code patterns before making changes
+5. Run `npm run build` to verify the codebase compiles
 
 ### Making Changes
 

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+# Devin AI API key (get from app.devin.ai Settings > API Keys)
+DEVIN_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/scripts/poll-devin-pr.sh
+++ b/scripts/poll-devin-pr.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="ljunggren/boozang-thelab"
+INTERVAL="${1:-60}"
+
+echo "Polling for new Devin PRs every ${INTERVAL}s on ${REPO}..."
+echo "Press Ctrl+C to stop."
+
+SEEN_PRS=""
+
+while true; do
+  PRS=$(gh pr list --repo "$REPO" --author "devin-ai-integration[bot]" --json number,title,url,createdAt --jq '.[] | "\(.number)\t\(.title)\t\(.url)"' 2>/dev/null || true)
+
+  if [ -n "$PRS" ]; then
+    while IFS= read -r line; do
+      PR_NUM=$(echo "$line" | cut -f1)
+      if [[ ! " $SEEN_PRS " =~ " $PR_NUM " ]]; then
+        SEEN_PRS="$SEEN_PRS $PR_NUM"
+        echo ""
+        echo "🔔 NEW PR from Devin!"
+        echo "$line" | awk -F'\t' '{printf "  #%s: %s\n  %s\n", $1, $2, $3}'
+        # macOS notification
+        osascript -e "display notification \"PR #${PR_NUM} opened by Devin\" with title \"Devin PR Ready\" sound name \"Glass\"" 2>/dev/null || true
+      fi
+    done <<< "$PRS"
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/scripts/trigger-devin.sh
+++ b/scripts/trigger-devin.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="ljunggren/boozang-thelab"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 <issue-number>"
+  exit 1
+fi
+
+ISSUE_NUMBER="$1"
+
+# Load API key
+if [ -f "$ENV_FILE" ]; then
+  source "$ENV_FILE"
+fi
+
+if [ -z "${DEVIN_API_KEY:-}" ]; then
+  echo "Error: DEVIN_API_KEY not set. Add it to .env or export it."
+  exit 1
+fi
+
+# Fetch issue details from GitHub
+ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title,url)
+ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url')
+
+PROMPT="Work on issue #${ISSUE_NUMBER} in ${REPO}: ${ISSUE_TITLE}
+
+Issue URL: ${ISSUE_URL}
+
+Read the full issue description at the URL above. Follow the branch naming, scope, and acceptance criteria specified in the issue. Open a PR when done."
+
+echo "Triggering Devin for issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+
+RESPONSE=$(curl -s -X POST https://api.devin.ai/v1/sessions \
+  -H "Authorization: Bearer ${DEVIN_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg prompt "$PROMPT" --arg title "Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}" '{prompt: $prompt, title: $title, idempotent: true}')")
+
+SESSION_URL=$(echo "$RESPONSE" | jq -r '.url // empty')
+
+if [ -z "$SESSION_URL" ]; then
+  echo "Error: Failed to create Devin session"
+  echo "$RESPONSE" | jq .
+  exit 1
+fi
+
+echo "Session created: $SESSION_URL"
+
+# Comment on the issue
+gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+  --body "🤖 Devin session triggered via API: ${SESSION_URL}"
+
+echo "Commented session link on issue #${ISSUE_NUMBER}"


### PR DESCRIPTION
## Summary
- Add `scripts/trigger-devin.sh` to create Devin sessions from GitHub issues via API
- Add `scripts/poll-devin-pr.sh` to poll for new PRs from Devin with macOS notifications
- Add `.env.template` for `DEVIN_API_KEY` and gitignore `.env`
- Update `.devin/guidelines.md` with branch tracking fix (`main` not `master`)

## Test plan
- [ ] Run `./scripts/trigger-devin.sh <issue-number>` — should create Devin session and comment on issue
- [ ] Run `./scripts/poll-devin-pr.sh` — should poll and notify on new Devin PRs
- [ ] Verify `.env` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)